### PR TITLE
Fix possible memory leak and enable StrictMode on sample app

### DIFF
--- a/android-radar/src/main/java/com/cedexis/androidradar/RadarSession.java
+++ b/android-radar/src/main/java/com/cedexis/androidradar/RadarSession.java
@@ -115,6 +115,7 @@ public class RadarSession {
         while ((line = bufferedReader.readLine()) != null) {
             result.append(line);
         }
+        in.close();
         return result.toString();
     }
 
@@ -333,7 +334,7 @@ public class RadarSession {
                 providers[providerIndex].process();
             } catch (JSONException e) {
                 e.printStackTrace();
-            };
+            }
         }
         Log.d(TAG, "Session complete");
     }

--- a/app/src/main/java/com/cedexis/simpleradardemo/DownloadProviderNamesTask.java
+++ b/app/src/main/java/com/cedexis/simpleradardemo/DownloadProviderNamesTask.java
@@ -8,6 +8,7 @@ import org.json.JSONObject;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -38,12 +39,14 @@ public class DownloadProviderNamesTask extends AsyncTask<Pair<Integer, Integer>,
         try {
             URL url = new URL(urlBuilder.toString());
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            BufferedReader r = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+            InputStream inputStream = connection.getInputStream();
+            BufferedReader r = new BufferedReader(new InputStreamReader(inputStream));
             StringBuilder source = new StringBuilder();
             String line;
             while ((line = r.readLine()) != null) {
                 source.append(line);
             }
+            inputStream.close();
             return new JSONObject(source.toString());
         } catch (IOException e) {
             e.printStackTrace();

--- a/app/src/main/java/com/cedexis/simpleradardemo/MainActivity.java
+++ b/app/src/main/java/com/cedexis/simpleradardemo/MainActivity.java
@@ -2,6 +2,7 @@ package com.cedexis.simpleradardemo;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.StrictMode;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.util.Pair;
@@ -45,6 +46,21 @@ public class MainActivity extends AppCompatActivity implements
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        // Enable Strict Mode for the sample app in order to detect issues on time.
+        StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
+                .detectDiskReads()
+                .detectDiskWrites()
+                .detectNetwork()
+                .penaltyLog()
+                .build());
+        StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
+                .detectLeakedSqlLiteObjects()
+                .detectLeakedClosableObjects()
+                .penaltyLog()
+                .penaltyDeath()
+                .build());
+
         setContentView(R.layout.activity_main);
 
         radarButton = (Button) findViewById(R.id.radar_button);


### PR DESCRIPTION
- Close all input streams after using them.
- Enable StrictMode with a policy to shutdown the app and print stack if there is an error.