### PR TITLE
Client profile reporting

### DIFF
--- a/android-radar/build.gradle
+++ b/android-radar/build.gradle
@@ -13,7 +13,7 @@ ext {
     siteUrl = 'https://github.com/cedexis/AndroidRadar'
     gitUrl = 'https://github.com/cedexis/AndroidRadar.git'
 
-    libraryVersion = '0.2.6'
+    libraryVersion = '0.2.7'
 
     developerId = 'cedexis'
     developerName = 'Cedexis'

--- a/android-radar/src/main/java/com/cedexis/androidradar/CedexisRadarWebClient.java
+++ b/android-radar/src/main/java/com/cedexis/androidradar/CedexisRadarWebClient.java
@@ -26,6 +26,10 @@ import java.util.Locale;
 
 class CedexisRadarWebClient extends WebViewClient {
 
+    // 2 is the client profile code for AndroidRadar
+    final int CLIENT_PROFILE = 2;
+    // Client profile version conveys the version of the WebView wrapper code.
+    final int CLIENT_PROFILE_VERSION = 1;
     final String TAG = CedexisRadarWebClient.class.getSimpleName();
     private final int zoneId;
     private final int customerId;
@@ -43,15 +47,21 @@ class CedexisRadarWebClient extends WebViewClient {
     @Override
     public void onPageFinished(WebView view, String url) {
         super.onPageFinished(view, url);
-        String startCommand = String.format(Locale.getDefault(), "cedexis.start(%d,%d);", zoneId, customerId);
+        String startCommand = String.format(
+                Locale.getDefault(),
+                "cedexis.start(%d,%d,%d,%d);",
+                zoneId,
+                customerId,
+                CLIENT_PROFILE,
+                CLIENT_PROFILE_VERSION);
         Log.d(TAG, String.format("Detected version: %d", Build.VERSION.SDK_INT));
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                Log.d(TAG, "Using evaluateJavascript");
+                Log.d(TAG, String.format("Using evaluateJavascript; start command=%s", startCommand));
                 view.evaluateJavascript("console.log('sending cedexis commands');", null);
                 view.evaluateJavascript(startCommand, null);
             } else {
-                Log.d(TAG, "Using loadUrl");
+                Log.d(TAG, String.format("Using loadUrl: start command: %s", startCommand));
                 view.loadUrl("javascript:console.log('sending cedexis commands');");
                 view.loadUrl("javascript:" + startCommand);
             }

--- a/android-radar/src/main/java/com/cedexis/androidradar/RadarWebView.java
+++ b/android-radar/src/main/java/com/cedexis/androidradar/RadarWebView.java
@@ -16,13 +16,13 @@
 
 package com.cedexis.androidradar;
 
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Build;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.WebSettings;
 import android.webkit.WebView;
 
 import java.util.Locale;
@@ -73,10 +73,15 @@ final class RadarWebView implements Radar {
         } else if (webView == null) {
             throw new IllegalAccessError("Call Radar#init method before sending Radar events");
         } else {
-            configureWebView(webView);
+            WebSettings settings = webView.getSettings();
+            settings.setJavaScriptEnabled(true);
+            settings.setAllowFileAccess(true);
+            settings.setAllowContentAccess(true);
+            settings.setAllowFileAccessFromFileURLs(true);
+            settings.setAllowUniversalAccessFromFileURLs(true);
             webView.setWebViewClient(createOrGetWebClient(zoneId, customerId));
             String url = String.format(Locale.getDefault(),
-                    "%s://%s/%d/%d/radar.html", scheme.toString(), RADAR_HOST, zoneId, customerId);
+                    "%s://%s/0/0/radar.html", scheme.toString(), RADAR_HOST);
             Log.d(TAG, String.format("Radar URL: %s", url));
             webView.loadUrl(url);
         }
@@ -88,27 +93,4 @@ final class RadarWebView implements Radar {
         }
         return webViewClient;
     }
-
-    /**
-     * Give all access to the webview to use JavaScript and allow universal access,
-     * only send {@link CedexisRadarWebClient} to only allow redirects on the same
-     * Radar host.
-     *
-     * @param webView
-     */
-    @SuppressLint("SetJavaScriptEnabled")
-    private void configureWebView(WebView webView) {
-        webView.getSettings().setJavaScriptEnabled(true);
-        webView.getSettings().setAllowFileAccess(true);
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-            webView.getSettings().setAllowContentAccess(true);
-        }
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            webView.getSettings().setAllowFileAccessFromFileURLs(true);
-            webView.getSettings().setAllowUniversalAccessFromFileURLs(true);
-        }
-    }
-
 }

--- a/app/src/main/java/com/cedexis/simpleradardemo/MainActivity.java
+++ b/app/src/main/java/com/cedexis/simpleradardemo/MainActivity.java
@@ -16,7 +16,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
     Button radarButton;
     private int requestorZoneId = 1;
-    private int requestorCustomerId = 22746;
+    private int requestorCustomerId = 10660;
     private Cedexis cedexis;
 
     @Override

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Feb 05 16:34:22 PST 2018
+#Fri Mar 30 12:21:13 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
- Adds client profile and profile version to `cedexis.start` call.
- Removes zid/cid from radar.html URL, similar to radar-runner for iOS.
- Further protection from running on Android APIs earlier than Nougat.

Won't merge and release this until downstream components are ready.