### PR TITLE
Swallow AndroidRuntimeException in init

### DIFF
--- a/android-radar/src/main/java/com/cedexis/androidradar/CedexisRadarWebClient.java
+++ b/android-radar/src/main/java/com/cedexis/androidradar/CedexisRadarWebClient.java
@@ -16,6 +16,7 @@
 
 package com.cedexis.androidradar;
 
+import android.annotation.TargetApi;
 import android.net.Uri;
 import android.os.Build;
 import android.util.Log;
@@ -29,7 +30,7 @@ class CedexisRadarWebClient extends WebViewClient {
     // 2 is the client profile code for AndroidRadar
     final int CLIENT_PROFILE = 2;
     // Client profile version conveys the version of the WebView wrapper code.
-    final int CLIENT_PROFILE_VERSION = 1;
+    final int CLIENT_PROFILE_VERSION = 2;
     final String TAG = CedexisRadarWebClient.class.getSimpleName();
     private final int zoneId;
     private final int customerId;
@@ -44,6 +45,7 @@ class CedexisRadarWebClient extends WebViewClient {
         return !Uri.parse(url).getHost().equals(RadarWebView.RADAR_HOST);
     }
 
+    @TargetApi(24)
     @Override
     public void onPageFinished(WebView view, String url) {
         super.onPageFinished(view, url);
@@ -56,15 +58,10 @@ class CedexisRadarWebClient extends WebViewClient {
                 CLIENT_PROFILE_VERSION);
         Log.d(TAG, String.format("Detected version: %d", Build.VERSION.SDK_INT));
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                Log.d(TAG, String.format("Using evaluateJavascript; start command=%s", startCommand));
-                view.evaluateJavascript("console.log('sending cedexis commands');", null);
-                view.evaluateJavascript(startCommand, null);
-            } else {
-                Log.d(TAG, String.format("Using loadUrl: start command: %s", startCommand));
-                view.loadUrl("javascript:console.log('sending cedexis commands');");
-                view.loadUrl("javascript:" + startCommand);
-            }
+            // `evaluateJavascript` is safe. Gated on API level 24+ upstream.
+            Log.d(TAG, String.format("Using evaluateJavascript; start command=%s", startCommand));
+            view.evaluateJavascript("console.log('sending cedexis commands');", null);
+            view.evaluateJavascript(startCommand, null);
         } catch (java.lang.IllegalStateException e) {
             // Just swallow for now. We believe this only emerges from a custom ROM bug, so it's
             // probably okay to surrender this data.

--- a/android-radar/src/main/java/com/cedexis/androidradar/RadarWebView.java
+++ b/android-radar/src/main/java/com/cedexis/androidradar/RadarWebView.java
@@ -16,9 +16,11 @@
 
 package com.cedexis.androidradar;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Build;
+import android.util.AndroidRuntimeException;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
@@ -39,24 +41,36 @@ final class RadarWebView implements Radar {
     private CedexisRadarWebClient webViewClient;
 
     RadarWebView(final Activity activity) {
-        final ViewGroup viewGroup = (ViewGroup) activity.getWindow().getDecorView().findViewById(android.R.id.content);
-        createWebView(activity, viewGroup);
+        if (validateRuntimeConditions()) {
+            final ViewGroup viewGroup = (ViewGroup) activity.getWindow().getDecorView().findViewById(android.R.id.content);
+            createWebView(activity, viewGroup);
+        }
     }
 
     RadarWebView(ViewGroup viewGroup) {
-        createWebView(viewGroup.getContext(), viewGroup);
+        if (validateRuntimeConditions()) {
+            createWebView(viewGroup.getContext(), viewGroup);
+        }
     }
 
     RadarWebView(final WebView webView) {
-        this.webView = webView;
-        this.webView.setVisibility(View.GONE);
+        if (validateRuntimeConditions()) {
+            this.webView = webView;
+            this.webView.setVisibility(View.GONE);
+        }
     }
 
     private void createWebView(Context context, ViewGroup viewGroup) {
-        webView = new WebView(context);
-        webView.setTag(TAG);
-        webView.setVisibility(View.GONE);
-        viewGroup.addView(webView);
+        try {
+            webView = new WebView(context);
+            webView.setTag(TAG);
+            webView.setVisibility(View.GONE);
+            viewGroup.addView(webView);
+        } catch (AndroidRuntimeException e) {
+            // Swallow this exception
+            Log.d(TAG, "AndroidRadar swallowing AndroidRuntimeException");
+            webView = null;
+        }
     }
 
     @Override
@@ -64,15 +78,10 @@ final class RadarWebView implements Radar {
         this.start(zoneId, customerId, RadarScheme.HTTP);
     }
 
+    @TargetApi(24)
     @Override
     public void start(final int zoneId, final int customerId, final RadarScheme scheme) {
-        if (Build.VERSION.SDK_INT < 24) {
-            // Resource Timing is probably not available, so let's skip.
-            // Also skipping HTTPS on versions of Android where TLS might be a problem (<APIv19)
-            Log.d(TAG, String.format("Skipping on API version %d", Build.VERSION.SDK_INT));
-        } else if (webView == null) {
-            throw new IllegalAccessError("Call Radar#init method before sending Radar events");
-        } else {
+        if (webView != null) {
             WebSettings settings = webView.getSettings();
             settings.setJavaScriptEnabled(true);
             settings.setAllowFileAccess(true);
@@ -84,6 +93,8 @@ final class RadarWebView implements Radar {
                     "%s://%s/0/0/radar.html", scheme.toString(), RADAR_HOST);
             Log.d(TAG, String.format("Radar URL: %s", url));
             webView.loadUrl(url);
+        } else {
+            Log.d(TAG, "AndroidRadar is missing a WebView to work with. This may be due to runtime requirements not being met or an exception occurring during WebView creation.");
         }
     }
 
@@ -92,5 +103,19 @@ final class RadarWebView implements Radar {
             webViewClient = new CedexisRadarWebClient(zoneId, customerId);
         }
         return webViewClient;
+    }
+
+    /**
+     * @return true if the runtime conditions are okay for AndroidRadar to run
+     */
+    private boolean validateRuntimeConditions() {
+        if (Build.VERSION.SDK_INT < 24) {
+            // Various issues arise when we run on API levels lower than 24:
+            // * Resource Timing is probably not available
+            // * TLS might be a problem (<APIv19)
+            Log.d(TAG, String.format("Detected API level less than 24 (%d). AndroidRadar going dormant.", Build.VERSION.SDK_INT));
+            return false;
+        }
+        return true;
     }
 }

--- a/app/src/main/java/com/cedexis/simpleradardemo/MainActivity.java
+++ b/app/src/main/java/com/cedexis/simpleradardemo/MainActivity.java
@@ -44,12 +44,12 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         radarButton.setOnClickListener(this);
 
         long l = System.currentTimeMillis();
-        cedexis = Cedexis.init(this);
-        Log.d("INIT WITH ACTIVITY", "Time: " + (System.currentTimeMillis() - l));
+        //cedexis = Cedexis.init(this);
+        //Log.d("INIT WITH ACTIVITY", "Time: " + (System.currentTimeMillis() - l));
 
-        l = System.currentTimeMillis();
-        cedexis = Cedexis.init((WebView) findViewById(R.id.webview));
-        Log.d("INIT WITH WEBVIEW", "Time: " + (System.currentTimeMillis() - l));
+        //l = System.currentTimeMillis();
+        //cedexis = Cedexis.init((WebView) findViewById(R.id.webview));
+        //Log.d("INIT WITH WEBVIEW", "Time: " + (System.currentTimeMillis() - l));
 
         l = System.currentTimeMillis();
         cedexis = Cedexis.init((ViewGroup) findViewById(R.id.content));

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 30 12:21:13 PDT 2018
+#Fri Sep 28 13:37:38 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
For https://jira.cedexis.com/browse/CEDEX-18406

Also includes a refactoring of the API 24 gating code so that it happens earlier during processing. Previously it had been invoked when the app starts a Radar session. Now it happens at the earliest possible moment so that on devices running Marshmallow (or earlier, including Lollipop where most of the errors have been reported), AndroidRadar can never get to the point where it would try to instantiate a WebView.

For API levels 24+, we swallow the AndroidRuntimeException and set the `webview` member to **null**. Downstream code protects against using this if null.

Caveat: I wasn't able to reproduce the issue using an emulator. The `Android System WebView` component is disabled in the Google Play store on Android 8 (at least in the emulator), and there is no combination of device definition and Android image that gives access to the Play Store using Lollipop. Instead I roughly tested the AndroidRuntimeException swallowing code by throwing one from within the try clause and seeing the expected log messages.