### PR TITLE
Remove unused dependency on the support library

### DIFF
--- a/android-radar/build.gradle
+++ b/android-radar/build.gradle
@@ -13,7 +13,7 @@ ext {
     siteUrl = 'https://github.com/cedexis/AndroidRadar'
     gitUrl = 'https://github.com/cedexis/AndroidRadar.git'
 
-    libraryVersion = '0.2.8'
+    libraryVersion = '0.2.9'
 
     developerId = 'cedexis'
     developerName = 'Cedexis'
@@ -51,7 +51,6 @@ allprojects {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:22.2.0'
 }
 
 group = publishedGroupId


### PR DESCRIPTION
Remove unused dependency on the support library.

Now clients don't have to enable jetifier for this library when migrating to androidx.
Closes: https://github.com/cedexis/AndroidRadar/issues/23